### PR TITLE
docs: github actions no longer in beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 ---
 
-> **:warning: Note:** To use this action, you must have access to the [GitHub Actions](https://github.com/features/actions) feature. GitHub Actions are currently only available in public beta. You can [apply for the GitHub Actions beta here](https://github.com/features/actions/signup/).
-
 ## Usage
 
 Below is a simple snippet to use this action.


### PR DESCRIPTION
Thus we can remove the note in the README